### PR TITLE
💚 fix(vercel): suppression de la configuration des fonctions pour optimiser le déploiement

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,11 +3,6 @@
   "installCommand": "npm install --legacy-peer-deps --verbose --network-timeout=300000",
   "framework": "angular",
   "outputDirectory": "dist/oypunu-frontend",
-  "functions": {
-    "app/**/*.ts": {
-      "maxDuration": 300
-    }
-  },
   "rewrites": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
Le problème était dans la configuration vercel.json - la section functions avec le pattern "app/**/*.ts" n'est pas applicable pour une application Angular frontend. Cette configuration est utilisée pour les serverless functions dans le dossier /api, mais O'Ypunu Frontend est une SPA Angular.