### PR TITLE
🔧 Correction des imports UserRole pour accès administration

### DIFF
--- a/src/app/features/admin/guards/admin.guard.ts
+++ b/src/app/features/admin/guards/admin.guard.ts
@@ -8,7 +8,7 @@ import {
 } from '@angular/router';
 import { Observable, map } from 'rxjs';
 import { AuthService } from '../../../core/services/auth.service';
-import { UserRole } from '../../../core/models/admin';
+import { UserRole } from '../models/comprehensive-admin.models';
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/shared/components/profile/profile.component.ts
+++ b/src/app/shared/components/profile/profile.component.ts
@@ -7,7 +7,7 @@ import {
 } from '@angular/core';
 import { AuthService } from '../../../core/services/auth.service';
 import { User } from '../../../core/models/user';
-import { UserRole } from '../../../core/models/admin';
+import { UserRole } from '../../../features/admin/models/comprehensive-admin.models';
 import { Subscription } from 'rxjs';
 
 @Component({


### PR DESCRIPTION
- Corrige AdminGuard: import UserRole depuis comprehensive-admin.models
- Corrige ProfileComponent: import UserRole depuis comprehensive-admin.models
- Résout les conflits d'imports causant les erreurs d'accès admin
- Assure la cohérence des enums UserRole dans toute l'application

✅ L'accès au menu administration devrait maintenant fonctionner